### PR TITLE
chore: add @types/dom-chromium-ai for better TypeScript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "devDependencies": {
     "@cloudflare/next-on-pages": "1",
     "@cloudflare/workers-types": "^4.20240605.0",
+    "@types/dom-chromium-ai": "^0.0.6",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20240605.0
         version: 4.20240605.0
+      '@types/dom-chromium-ai':
+        specifier: ^0.0.6
+        version: 0.0.6
       '@types/node':
         specifier: ^20
         version: 20.14.2
@@ -567,28 +570,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.1.0':
     resolution: {integrity: sha512-v6kP8sHYxjO8RwHmWMJSq7VZP2nYCkRVQ0qolh2l6xroe9QjbgV8siTbduED4u0hlk0+tjS6/Tuy4n5XCp+l6g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.1.0':
     resolution: {integrity: sha512-zJ2pnoFYB1F4vmEVlb/eSe+VH679zT1VdXlZKX+pE66grOgjmKJHKacf82g/sWE4MQ4Rk2FMBCRnX+l6/TVYzQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.1.0':
     resolution: {integrity: sha512-rbaIYFt2X9YZBSbH/CwGAjbBG2/MrACCVu2X0+kSykHzHnYH5FjHxwXLkcoJ10cX0aWCEynpu+rP76x0914atg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.1.0':
     resolution: {integrity: sha512-o1N5TsYc8f/HpGt39OUQpQ9AKIGApd3QLueu7hXk//2xq5Z9OxmV6sQfNp8C7qYmiOlHYODOGqNNa0e9jvchGQ==}
@@ -1268,6 +1267,9 @@ packages:
 
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@types/dom-chromium-ai@0.0.6':
+    resolution: {integrity: sha512-/jUGe9a3BLzsjjg18Olk/Ul64PZ0P4aw8uNxrXeXVTni5PSxyCfyhHb4UohsXNVByOnwYGzlqUcb3vYKVsG4mg==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -4936,6 +4938,8 @@ snapshots:
   '@tsconfig/node14@1.0.3': {}
 
   '@tsconfig/node16@1.0.4': {}
+
+  '@types/dom-chromium-ai@0.0.6': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:

--- a/src/components/chatbox.tsx
+++ b/src/components/chatbox.tsx
@@ -6,32 +6,6 @@ import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { useRef } from "react";
 
-type AIModelAvailability = 'readily' | 'after-download' | 'no';
-
-declare global {
-  interface Window {
-    ai: AI;
-  }
-
-  interface AI {
-    languageModel: {
-      create(): Promise<AITextSession>;
-      capabilities(): Promise<{
-        available: AIModelAvailability;
-        defaultTemperature?: number;
-        defaultTopK?: number;
-        maxTemperature?: number;
-        maxTopK?: number;
-      }>;
-    };
-  }
-
-  interface AITextSession {
-    prompt(input: string): Promise<string>;
-    promptStreaming(input: string): AsyncGenerator<string>;
-  }
-}
-
 const checkAI = async () => {
   if ("ai" in window) {
     const available = (await window.ai.languageModel.capabilities()).available
@@ -45,7 +19,7 @@ const checkAI = async () => {
 export default function ChatBox() {
   const rawChatHistory = useRef<any[]>([]);
   const [endMessage, setEndMessage] = useState<null | HTMLDivElement>(null);
-  const [session, setSession] = useState<null | AITextSession>(null);
+  const [session, setSession] = useState<null | AILanguageModel>(null);
   const [isAI, setIsAI] = useState<null | boolean>(null);
   const [inputValue, setInputValue] = useState("");
   const [inferring, setInferring] = useState(false);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
       "@/*": ["./src/*"]
     },
     "types": [
-        "@cloudflare/workers-types/2023-07-01"
+        "@cloudflare/workers-types/2023-07-01",
+        "@types/dom-chromium-ai"
     ]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
Hi,
I just found the [@types/dom-chromium-ai](https://www.npmjs.com/package/@types/dom-chromium-ai) which contains type definitions for `dom-chromium-ai`, so we don't need to type it by ourselves. In this PR, I removed self-created type definitions and added `@types/dom-chromium-ai` package.